### PR TITLE
All Functions now have proper Verb-Noun Naming

### DIFF
--- a/Functions/InventoryRuleManagement.ps1
+++ b/Functions/InventoryRuleManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddExpression {
+Function Add-Expression {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function AddExpression {
 }
 
 
-Function AddOperatorToExpression {
+Function Add-OperatorToExpression {
 
 <#
 .SYNOPSIS
@@ -115,7 +115,7 @@ Function AddOperatorToExpression {
 }
 
 
-Function CreateExpression64BitWindowsInstalled {
+Function New-Expression64BitWindowsInstalled {
 
 <#
 .SYNOPSIS
@@ -155,7 +155,7 @@ Function CreateExpression64BitWindowsInstalled {
 }
 
 
-Function CreateExpressionFileVersion {
+Function New-ExpressionFileVersion {
 
 <#
 .SYNOPSIS
@@ -225,7 +225,7 @@ Function CreateExpressionFileVersion {
 }
 
 
-Function CreateExpressionMSIProductCode {
+Function New-ExpressionMSIProductCode {
 
 <#
 .SYNOPSIS
@@ -271,7 +271,7 @@ Function CreateExpressionMSIProductCode {
 }
 
 
-Function CreateExpressionMUIInstalled {
+Function New-ExpressionMUIInstalled {
 
 <#
 .SYNOPSIS
@@ -311,7 +311,7 @@ Function CreateExpressionMUIInstalled {
 }
 
 
-Function CreateExpressionProcessorType {
+Function New-ExpressionProcessorType {
 
 <#
 .SYNOPSIS
@@ -357,7 +357,7 @@ Function CreateExpressionProcessorType {
 }
 
 
-Function CreateExpressionRegistryKeyExits {
+Function New-ExpressionRegistryKeyExists {
 
 <#
 .SYNOPSIS
@@ -403,7 +403,7 @@ Function CreateExpressionRegistryKeyExits {
 }
 
 
-Function CreateExpressionRegistryKeyPathToFileVersion {
+Function New-ExpressionRegistryKeyPathToFileVersion {
 
 <#
 .SYNOPSIS
@@ -479,7 +479,7 @@ Function CreateExpressionRegistryKeyPathToFileVersion {
 }
 
 
-Function CreateExpressionRegistryKeyPathToProductVersion {
+Function New-ExpressionRegistryKeyPathToProductVersion {
 
 <#
 .SYNOPSIS
@@ -549,7 +549,7 @@ Function CreateExpressionRegistryKeyPathToProductVersion {
 }
 
 
-Function CreateExpressionRegistryKeyToFileVersion {
+Function New-ExpressionRegistryKeyToFileVersion {
 
 <#
 .SYNOPSIS
@@ -619,7 +619,7 @@ Function CreateExpressionRegistryKeyToFileVersion {
 }
 
 
-Function CreateExpressionRegistryKeyValue {
+Function New-ExpressionRegistryKeyValue {
 
 <#
 .SYNOPSIS
@@ -683,7 +683,7 @@ Function CreateExpressionRegistryKeyValue {
 }
 
 
-Function CreateExpressionRegistryKeyVersion {
+Function New-ExpressionRegistryKeyVersion {
 
 <#
 .SYNOPSIS
@@ -753,7 +753,7 @@ Function CreateExpressionRegistryKeyVersion {
 }
 
 
-Function CreateExpressionSoftwareFile {
+Function New-ExpressionSoftwareFile {
 
 <#
 .SYNOPSIS
@@ -829,7 +829,7 @@ Function CreateExpressionSoftwareFile {
 }
 
 
-Function CreateExpressionSoftwareFileAddFile {
+Function New-ExpressionSoftwareFileAddFile {
 
 <#
 .SYNOPSIS
@@ -905,7 +905,7 @@ Function CreateExpressionSoftwareFileAddFile {
 }
 
 
-Function CreateExpressionStaticFile {
+Function New-ExpressionStaticFile {
 
 <#
 .SYNOPSIS
@@ -981,7 +981,7 @@ Function CreateExpressionStaticFile {
 }
 
 
-Function CreateExpressionStaticShortcutTarget {
+Function New-ExpressionStaticShortcutTarget {
 
 <#
 .SYNOPSIS
@@ -1033,7 +1033,7 @@ Function CreateExpressionStaticShortcutTarget {
 }
 
 
-Function CreateExpressionWindowsLanguage {
+Function New-ExpressionWindowsLanguage {
 
 <#
 .SYNOPSIS
@@ -1079,7 +1079,7 @@ Function CreateExpressionWindowsLanguage {
 }
 
 
-Function CreateExpressionWindowsVersion {
+Function New-ExpressionWindowsVersion {
 
 <#
 .SYNOPSIS
@@ -1173,7 +1173,7 @@ Function CreateExpressionWindowsVersion {
 }
 
 
-Function CreateInventoryRule {
+Function New-InventoryRule {
 
 <#
 .SYNOPSIS
@@ -1231,7 +1231,7 @@ Function CreateInventoryRule {
 }
 
 
-Function CreateInventoryRuleFromExpression {
+Function New-InventoryRuleFromExpression {
 
 <#
 .SYNOPSIS
@@ -1289,7 +1289,7 @@ Function CreateInventoryRuleFromExpression {
 }
 
 
-Function ExportRuleDefinition {
+Function Export-RuleDefinition {
 
 <#
 .SYNOPSIS
@@ -1341,7 +1341,7 @@ Function ExportRuleDefinition {
 }
 
 
-Function ExportRuleDefinitionsFromComponent {
+Function Export-RuleDefinitionsFromComponent {
 
 <#
 .SYNOPSIS
@@ -1399,7 +1399,7 @@ Function ExportRuleDefinitionsFromComponent {
 }
 
 
-Function GetExpressionsFromRule {
+Function Get-ExpressionsFromRule {
 
 <#
 .SYNOPSIS
@@ -1445,7 +1445,7 @@ Function GetExpressionsFromRule {
 }
 
 
-Function GetExpressionsFromRuleFile {
+Function Get-ExpressionsFromRuleFile {
 
 <#
 .SYNOPSIS
@@ -1491,7 +1491,7 @@ Function GetExpressionsFromRuleFile {
 }
 
 
-Function RemoveExpression {
+Function Remove-Expression {
 
 <#
 .SYNOPSIS
@@ -1543,7 +1543,7 @@ Function RemoveExpression {
 }
 
 
-Function UpdateInventoryRule {
+Function Update-InventoryRule {
 
 <#
 .SYNOPSIS
@@ -1595,7 +1595,7 @@ Function UpdateInventoryRule {
 }
 
 
-Function UpdateInventoryRuleFromExpression {
+Function Update-InventoryRuleFromExpression {
 
 <#
 .SYNOPSIS

--- a/Functions/ItemManagement.ps1
+++ b/Functions/ItemManagement.ps1
@@ -51,7 +51,7 @@ Function CloneItem {
 }
 
 
-Function CreateFolder {
+Function New-Folder {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function CreateFolder {
 }
 
 
-Function DeleteItem {
+Function Remove-Item {
 
 <#
 .SYNOPSIS
@@ -149,7 +149,7 @@ Function DeleteItem {
 }
 
 
-Function DisablePolicyItem {
+Function Disable-PolicyItem {
 
 <#
 .SYNOPSIS
@@ -195,7 +195,7 @@ Function DisablePolicyItem {
 }
 
 
-Function EnablePolicyItem {
+Function Enable-PolicyItem {
 
 <#
 .SYNOPSIS
@@ -241,7 +241,7 @@ Function EnablePolicyItem {
 }
 
 
-Function ExecuteSchedulableItem {
+Function Invoke-SchedulableItem {
 
 <#
 .SYNOPSIS
@@ -287,7 +287,7 @@ Function ExecuteSchedulableItem {
 }
 
 
-Function ExportItemProfileXmlString {
+Function Export-ItemProfileXmlString {
 
 <#
 .SYNOPSIS
@@ -339,7 +339,7 @@ Function ExportItemProfileXmlString {
 }
 
 
-Function ExportItemXml {
+Function Export-ItemXml {
 
 <#
 .SYNOPSIS
@@ -391,7 +391,7 @@ Function ExportItemXml {
 }
 
 
-Function ExportItemXmlString {
+Function Export-ItemXmlString {
 
 <#
 .SYNOPSIS
@@ -437,7 +437,7 @@ Function ExportItemXmlString {
 }
 
 
-Function GetItemByGuid {
+Function Get-ItemByGuid {
 
 <#
 .SYNOPSIS
@@ -483,7 +483,7 @@ Function GetItemByGuid {
 }
 
 
-Function GetItemsByName {
+Function Get-ItemsByName {
 
 <#
 .SYNOPSIS
@@ -529,7 +529,7 @@ Function GetItemsByName {
 }
 
 
-Function GetItemsByNameAndType {
+Function Get-ItemsByNameAndType {
 
 <#
 .SYNOPSIS
@@ -581,7 +581,7 @@ Function GetItemsByNameAndType {
 }
 
 
-Function GetItemsByType {
+Function Get-ItemsByType {
 
 <#
 .SYNOPSIS
@@ -627,7 +627,7 @@ Function GetItemsByType {
 }
 
 
-Function GetItemsInFolder {
+Function Get-ItemsInFolder {
 
 <#
 .SYNOPSIS
@@ -673,7 +673,7 @@ Function GetItemsInFolder {
 }
 
 
-Function ImportItemXmlFile {
+Function Import-ItemXmlFile {
 
 <#
 .SYNOPSIS
@@ -719,7 +719,7 @@ Function ImportItemXmlFile {
 }
 
 
-Function ImportItemXmlFiles {
+Function Import-ItemXmlFiles {
 
 <#
 .SYNOPSIS
@@ -765,7 +765,7 @@ Function ImportItemXmlFiles {
 }
 
 
-Function ImportItemXmlString {
+Function Import-ItemXmlString {
 
 <#
 .SYNOPSIS
@@ -811,7 +811,7 @@ Function ImportItemXmlString {
 }
 
 
-Function ItemExists {
+Function Test-ItemExists {
 
 <#
 .SYNOPSIS
@@ -857,7 +857,7 @@ Function ItemExists {
 }
 
 
-Function MoveItem {
+Function Move-Item {
 
 <#
 .SYNOPSIS
@@ -909,7 +909,7 @@ Function MoveItem {
 }
 
 
-Function RenameItem {
+Function Rename-Item {
 
 <#
 .SYNOPSIS
@@ -961,7 +961,7 @@ Function RenameItem {
 }
 
 
-Function RunAutomationPolicyTask {
+Function Invoke-AutomationPolicyTask {
 
 <#
 .SYNOPSIS
@@ -1007,7 +1007,7 @@ Function RunAutomationPolicyTask {
 }
 
 
-Function SetItemsSchedule {
+Function Set-ItemsSchedule {
 
 <#
 .SYNOPSIS

--- a/Functions/PatchManagement.ps1
+++ b/Functions/PatchManagement.ps1
@@ -63,7 +63,7 @@ Function AddGuids {
 }
 
 
-Function CreateAgentPluginPolicy {
+Function New-PatchAgentPluginPolicy {
 
 <#
 .SYNOPSIS
@@ -127,7 +127,7 @@ Function CreateAgentPluginPolicy {
 }
 
 
-Function CreateUpdatePolicy {
+Function New-PatchUpdatePolicy {
 
 <#
 .SYNOPSIS
@@ -191,7 +191,7 @@ Function CreateUpdatePolicy {
 }
 
 
-Function EnsureStaged {
+Function Test-PatchBulletinStaged {
 
 <#
 .SYNOPSIS
@@ -243,7 +243,7 @@ Function EnsureStaged {
 }
 
 
-Function GetAllStagedUpdates {
+Function Get-PatchStagedUpdates {
 
 <#
 .SYNOPSIS
@@ -283,7 +283,7 @@ Function GetAllStagedUpdates {
 }
 
 
-Function GetCustomSeverities {
+Function Get-PatchCustomSeverities {
 
 <#
 .SYNOPSIS
@@ -323,7 +323,7 @@ Function GetCustomSeverities {
 }
 
 
-Function GetCustomSeverityLevels {
+Function Get-PatchCustomSeverityLevels {
 
 <#
 .SYNOPSIS
@@ -363,7 +363,7 @@ Function GetCustomSeverityLevels {
 }
 
 
-Function GetDistributionTaskStatus {
+Function Get-PatchDistributionTaskStatus {
 
 <#
 .SYNOPSIS
@@ -403,7 +403,7 @@ Function GetDistributionTaskStatus {
 }
 
 
-Function GetNonstagedUpdates {
+Function Get-PathcNonstagedUpdates {
 
 <#
 .SYNOPSIS
@@ -449,7 +449,7 @@ Function GetNonstagedUpdates {
 }
 
 
-Function GetPackageServerGuid {
+Function Get-PackageServerGuid {
 
 <#
 .SYNOPSIS
@@ -489,7 +489,7 @@ Function GetPackageServerGuid {
 }
 
 
-Function GetPreImportStatus {
+Function Get-PatchPreImportStatus {
 
 <#
 .SYNOPSIS
@@ -535,7 +535,7 @@ Function GetPreImportStatus {
 }
 
 
-Function GetPreImportStatusVerbose {
+Function Get-PatchPreImportStatusVerbose {
 
 <#
 .SYNOPSIS
@@ -581,7 +581,7 @@ Function GetPreImportStatusVerbose {
 }
 
 
-Function GetProperty {
+Function Get-PatchProperty {
 
 <#
 .SYNOPSIS
@@ -633,7 +633,7 @@ Function GetProperty {
 }
 
 
-Function GetStagedUpdates {
+Function Get-PatchStagedUpdates {
 
 <#
 .SYNOPSIS
@@ -679,7 +679,7 @@ Function GetStagedUpdates {
 }
 
 
-Function GetStagingTaskStatus {
+Function Get-PatchStagingTaskStatus {
 
 <#
 .SYNOPSIS
@@ -719,7 +719,7 @@ Function GetStagingTaskStatus {
 }
 
 
-Function GetTaskInstanceStatus {
+Function Get-PatchTaskInstanceStatus {
 
 <#
 .SYNOPSIS
@@ -765,7 +765,7 @@ Function GetTaskInstanceStatus {
 }
 
 
-Function GetTaskRunningInstances {
+Function Get-PatchTaskRunningInstances {
 
 <#
 .SYNOPSIS
@@ -811,7 +811,7 @@ Function GetTaskRunningInstances {
 }
 
 
-Function GetWindowsPreImportStatus {
+Function Get-PatchWindowsPreImportStatus {
 
 <#
 .SYNOPSIS
@@ -851,7 +851,7 @@ Function GetWindowsPreImportStatus {
 }
 
 
-Function GetWindowsPreImportStatusVerbose {
+Function Get-PatchWindowsPreImportStatusVerbose {
 
 <#
 .SYNOPSIS
@@ -891,7 +891,7 @@ Function GetWindowsPreImportStatusVerbose {
 }
 
 
-Function IsCleanUpAfterUpgrade71Finished {
+Function Get-IsCleanUpAfterUpgrade71Finished {
 
 <#
 .SYNOPSIS
@@ -931,7 +931,7 @@ Function IsCleanUpAfterUpgrade71Finished {
 }
 
 
-Function IsSoftwareUpdateDistributionRunning {
+Function Get-PatchSoftwareUpdateDistributionRunning {
 
 <#
 .SYNOPSIS
@@ -971,7 +971,7 @@ Function IsSoftwareUpdateDistributionRunning {
 }
 
 
-Function IsStaged {
+Function Get-PatchBulletinStaged {
 
 <#
 .SYNOPSIS
@@ -1017,7 +1017,7 @@ Function IsStaged {
 }
 
 
-Function IsStagingTaskRunning {
+Function Get-PatchIsStagingTaskRunning {
 
 <#
 .SYNOPSIS
@@ -1057,7 +1057,7 @@ Function IsStagingTaskRunning {
 }
 
 
-Function IsTaskRunning {
+Function Get-IsTaskRunning {
 
 <#
 .SYNOPSIS
@@ -1103,7 +1103,7 @@ Function IsTaskRunning {
 }
 
 
-Function MyPrivileges {
+Function Get-MyPrivileges {
 
 <#
 .SYNOPSIS
@@ -1143,7 +1143,7 @@ Function MyPrivileges {
 }
 
 
-Function OperatePatchWorker {
+Function Invoke-PatchWorker {
 
 <#
 .SYNOPSIS
@@ -1201,7 +1201,7 @@ Function OperatePatchWorker {
 }
 
 
-Function ResolveToPolicies {
+Function Resolve-PatchBulletinToPolicies {
 
 <#
 .SYNOPSIS
@@ -1247,7 +1247,7 @@ Function ResolveToPolicies {
 }
 
 
-Function ResolveToUpdates {
+Function Resolve-PatchBulletinToUpdates {
 
 <#
 .SYNOPSIS
@@ -1293,7 +1293,7 @@ Function ResolveToUpdates {
 }
 
 
-Function RunCleanUpAfterUpgrade71 {
+Function Invoke-CleanUpAfterUpgrade71 {
 
 <#
 .SYNOPSIS
@@ -1333,7 +1333,7 @@ Function RunCleanUpAfterUpgrade71 {
 }
 
 
-Function RunPatchWorker {
+Function Invoke-PatchWorker {
 
 <#
 .SYNOPSIS
@@ -1385,7 +1385,7 @@ Function RunPatchWorker {
 }
 
 
-Function RunPreImport {
+Function Invoke-PatchPreImport {
 
 <#
 .SYNOPSIS
@@ -1431,7 +1431,7 @@ Function RunPreImport {
 }
 
 
-Function RunTask {
+Function Invoke-Task {
 
 <#
 .SYNOPSIS
@@ -1483,7 +1483,7 @@ Function RunTask {
 }
 
 
-Function RunWindowsPreImport {
+Function Invoke-PatchWindowsPreImport {
 
 <#
 .SYNOPSIS
@@ -1523,7 +1523,7 @@ Function RunWindowsPreImport {
 }
 
 
-Function SetPluginPolicyMessages {
+Function Set-PatchPluginPolicyMessages {
 
 <#
 .SYNOPSIS
@@ -1605,7 +1605,7 @@ Function SetPluginPolicyMessages {
 }
 
 
-Function SetPluginPolicySchedules {
+Function Set-PatchPluginPolicySchedules {
 
 <#
 .SYNOPSIS
@@ -1669,7 +1669,7 @@ Function SetPluginPolicySchedules {
 }
 
 
-Function SetProperties {
+Function Set-PatchProperties {
 
 <#
 .SYNOPSIS
@@ -1721,7 +1721,7 @@ Function SetProperties {
 }
 
 
-Function SetProperty {
+Function Set-PatchProperty {
 
 <#
 .SYNOPSIS
@@ -1779,7 +1779,7 @@ Function SetProperty {
 }
 
 
-Function SetSeverityLevel {
+Function Set-PatchSeverityLevel {
 
 <#
 .SYNOPSIS
@@ -1831,7 +1831,7 @@ Function SetSeverityLevel {
 }
 
 
-Function SetSoftwareUpdatePolicySchedule {
+Function Set-PatchSoftwareUpdatePolicySchedule {
 
 <#
 .SYNOPSIS
@@ -1883,7 +1883,7 @@ Function SetSoftwareUpdatePolicySchedule {
 }
 
 
-Function SetSoftwareUpdatePolicyTargets {
+Function Set-PatchSoftwareUpdatePolicyTargets {
 
 <#
 .SYNOPSIS
@@ -1935,7 +1935,7 @@ Function SetSoftwareUpdatePolicyTargets {
 }
 
 
-Function SetupImport {
+Function Set-PatchImport {
 
 <#
 .SYNOPSIS
@@ -1987,7 +1987,7 @@ Function SetupImport {
 }
 
 
-Function SetupPreImport {
+Function Initialize-PatchPreImport {
 
 <#
 .SYNOPSIS
@@ -2051,7 +2051,7 @@ Function SetupPreImport {
 }
 
 
-Function SetupWindowsPreImport {
+Function Initialize-PatchWindowsPreImport {
 
 <#
 .SYNOPSIS
@@ -2109,7 +2109,7 @@ Function SetupWindowsPreImport {
 }
 
 
-Function StopPatchWorker {
+Function Stop-PatchWorker {
 
 <#
 .SYNOPSIS
@@ -2155,7 +2155,7 @@ Function StopPatchWorker {
 }
 
 
-Function StopPreImport {
+Function Stop-PatchPreImport {
 
 <#
 .SYNOPSIS
@@ -2201,7 +2201,7 @@ Function StopPreImport {
 }
 
 
-Function StopWindowsPreImport {
+Function Stop-PatchWindowsPreImport {
 
 <#
 .SYNOPSIS
@@ -2241,7 +2241,7 @@ Function StopWindowsPreImport {
 }
 
 
-Function UpdateResourceTargets {
+Function Update-PatchResourceTargets {
 
 <#
 .SYNOPSIS
@@ -2287,7 +2287,7 @@ Function UpdateResourceTargets {
 }
 
 
-Function UpdateSoftwareUpdatePolicy {
+Function Update-PatchSoftwareUpdatePolicy {
 
 <#
 .SYNOPSIS

--- a/Functions/ResourceManagement.ps1
+++ b/Functions/ResourceManagement.ps1
@@ -1,5 +1,5 @@
 
-Function CreateResourceAssociation {
+Function New-ResourceAssociation {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function CreateResourceAssociation {
 }
 
 
-Function GetComputerByNameAndDomain {
+Function Get-ComputerByNameAndDomain {
 
 <#
 .SYNOPSIS
@@ -109,7 +109,7 @@ Function GetComputerByNameAndDomain {
 }
 
 
-Function GetDataClassData {
+Function Get-DataClassData {
 
 <#
 .SYNOPSIS
@@ -161,7 +161,7 @@ Function GetDataClassData {
 }
 
 
-Function GetResourceByContext {
+Function Get-ResourceByContext {
 
 <#
 .SYNOPSIS
@@ -207,7 +207,7 @@ Function GetResourceByContext {
 }
 
 
-Function GetResourceByName {
+Function Get-ResourceByName {
 
 <#
 .SYNOPSIS
@@ -259,7 +259,7 @@ Function GetResourceByName {
 }
 
 
-Function GetUserByUserIdAndDomain {
+Function Get-UserByUserIdAndDomain {
 
 <#
 .SYNOPSIS
@@ -311,7 +311,7 @@ Function GetUserByUserIdAndDomain {
 }
 
 
-Function MergeResource {
+Function Merge-Resource {
 
 <#
 .SYNOPSIS
@@ -363,7 +363,7 @@ Function MergeResource {
 }
 
 
-Function PushAltirisAgentToComputers {
+Function Install-AltirisAgentToComputers {
 
 <#
 .SYNOPSIS
@@ -439,7 +439,7 @@ Function PushAltirisAgentToComputers {
 }
 
 
-Function PushAltirisAgentToComputersStrict {
+Function Install-AltirisAgentToComputersStrict {
 
 <#
 .SYNOPSIS

--- a/Functions/SWDSolnAdvertisementManagement.ps1
+++ b/Functions/SWDSolnAdvertisementManagement.ps1
@@ -1,5 +1,5 @@
 
-Function CreateAdvertisementEx {
+Function New-SWDAdvertisement {
 
 <#
 .SYNOPSIS
@@ -87,7 +87,7 @@ Function CreateAdvertisementEx {
 }
 
 
-Function GetAdvertisementExByGuid {
+Function Get-SWDAdvertisementByGuid {
 
 <#
 .SYNOPSIS
@@ -133,7 +133,7 @@ Function GetAdvertisementExByGuid {
 }
 
 
-Function GetAdvertisementExStatusByResourceGuid {
+Function Get-SWDAdvertisementStatusByResourceGuid {
 
 <#
 .SYNOPSIS
@@ -185,7 +185,7 @@ Function GetAdvertisementExStatusByResourceGuid {
 }
 
 
-Function GetAdvertisementExStatusByResourceName {
+Function Get-SWDAdvertisementStatusByResourceName {
 
 <#
 .SYNOPSIS
@@ -237,7 +237,7 @@ Function GetAdvertisementExStatusByResourceName {
 }
 
 
-Function GetAdvertisementExStatusByResourceTargetGuid {
+Function Get-SWDAdvertisementStatusByResourceTargetGuid {
 
 <#
 .SYNOPSIS
@@ -289,7 +289,7 @@ Function GetAdvertisementExStatusByResourceTargetGuid {
 }
 
 
-Function GetAdvertismentExRunTimeByResourceGuid {
+Function Get-SWDAdvertismentRunTimeByResourceGuid {
 
 <#
 .SYNOPSIS
@@ -341,7 +341,7 @@ Function GetAdvertismentExRunTimeByResourceGuid {
 }
 
 
-Function GetAdvertismentExRunTimeByResourceName {
+Function Get-SWDAdvertismentRunTimeByResourceName {
 
 <#
 .SYNOPSIS
@@ -393,7 +393,7 @@ Function GetAdvertismentExRunTimeByResourceName {
 }
 
 
-Function ModifyAdvertisementExBasic {
+Function Set-SWDAdvertisementBasic {
 
 <#
 .SYNOPSIS
@@ -451,7 +451,7 @@ Function ModifyAdvertisementExBasic {
 }
 
 
-Function ModifyAdvertisementExDetail {
+Function Set-SWDAdvertisementDetail {
 
 <#
 .SYNOPSIS
@@ -533,7 +533,7 @@ Function ModifyAdvertisementExDetail {
 }
 
 
-Function ModifyResourceTargets {
+Function Set-SWDResourceTargets {
 
 <#
 .SYNOPSIS
@@ -591,7 +591,7 @@ Function ModifyResourceTargets {
 }
 
 
-Function SetAdvertisementExAgentSettings {
+Function Set-SWDAdvertisementAgentSettings {
 
 <#
 .SYNOPSIS
@@ -685,7 +685,7 @@ Function SetAdvertisementExAgentSettings {
 }
 
 
-Function SetAdvertisementExRunOptions {
+Function Set-SWDAdvertisementRunOptions {
 
 <#
 .SYNOPSIS
@@ -761,7 +761,7 @@ Function SetAdvertisementExRunOptions {
 }
 
 
-Function SetAdvertisementExScheduleRunASAP {
+Function Set-SWDAdvertisementScheduleRunASAP {
 
 <#
 .SYNOPSIS

--- a/Functions/SWDSolnPackageManagement.ps1
+++ b/Functions/SWDSolnPackageManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddProgramToPackage {
+Function Add-SWDProgramToPackage {
 
 <#
 .SYNOPSIS
@@ -51,7 +51,7 @@ Function AddProgramToPackage {
 }
 
 
-Function CreatePackageExBasic {
+Function New-SWDPackageBasic {
 
 <#
 .SYNOPSIS
@@ -115,7 +115,7 @@ Function CreatePackageExBasic {
 }
 
 
-Function CreatePackageExDetail {
+Function New-SWDPackageDetail {
 
 <#
 .SYNOPSIS
@@ -209,7 +209,7 @@ Function CreatePackageExDetail {
 }
 
 
-Function GetPackageExByGuid {
+Function Get-SWDPackageByGuid {
 
 <#
 .SYNOPSIS
@@ -255,7 +255,7 @@ Function GetPackageExByGuid {
 }
 
 
-Function ModifyPackageExBasic {
+Function Set-SWDPackageBasic {
 
 <#
 .SYNOPSIS
@@ -325,7 +325,7 @@ Function ModifyPackageExBasic {
 }
 
 
-Function ModifyPackageExDetail {
+Function Set-SWDPackageDetail {
 
 <#
 .SYNOPSIS
@@ -425,7 +425,7 @@ Function ModifyPackageExDetail {
 }
 
 
-Function SetPackageExAdvancedOptions {
+Function Set-SWDPackageAdvancedOptions {
 
 <#
 .SYNOPSIS
@@ -495,7 +495,7 @@ Function SetPackageExAdvancedOptions {
 }
 
 
-Function SetPackageExPackageServerOptions {
+Function Set-SWDPackageServerOptions {
 
 <#
 .SYNOPSIS
@@ -559,7 +559,7 @@ Function SetPackageExPackageServerOptions {
 }
 
 
-Function UpdateDistributionPoints {
+Function Update-SWDDistributionPoints {
 
 <#
 .SYNOPSIS

--- a/Functions/SWDSolnProgramManagement.ps1
+++ b/Functions/SWDSolnProgramManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AssignSoftwarePortalSecurity {
+Function Set-SWDSoftwarePortalSecurity {
 
 <#
 .SYNOPSIS
@@ -63,7 +63,7 @@ Function AssignSoftwarePortalSecurity {
 }
 
 
-Function CreateProgramExBasic {
+Function New-SWDProgramBasic {
 
 <#
 .SYNOPSIS
@@ -115,7 +115,7 @@ Function CreateProgramExBasic {
 }
 
 
-Function CreateProgramExDetail {
+Function New-SWDProgramDetail {
 
 <#
 .SYNOPSIS
@@ -209,7 +209,7 @@ Function CreateProgramExDetail {
 }
 
 
-Function GetProgramExByGuid {
+Function Get-SWDProgramByGuid {
 
 <#
 .SYNOPSIS
@@ -255,7 +255,7 @@ Function GetProgramExByGuid {
 }
 
 
-Function GetProgramsFromPackage {
+Function Get-SWDProgramsFromPackage {
 
 <#
 .SYNOPSIS
@@ -301,7 +301,7 @@ Function GetProgramsFromPackage {
 }
 
 
-Function ModifyProgramExBasic {
+Function Set-SWDProgramBasic {
 
 <#
 .SYNOPSIS
@@ -359,7 +359,7 @@ Function ModifyProgramExBasic {
 }
 
 
-Function ModifyProgramExDetail {
+Function Set-SWDProgramDetail {
 
 <#
 .SYNOPSIS
@@ -459,7 +459,7 @@ Function ModifyProgramExDetail {
 }
 
 
-Function SetProgramExecutionOptions {
+Function Set-SWDProgramExecutionOptions {
 
 <#
 .SYNOPSIS
@@ -559,7 +559,7 @@ Function SetProgramExecutionOptions {
 }
 
 
-Function SetProgramNetworkOptions {
+Function Set-SWDProgramNetworkOptions {
 
 <#
 .SYNOPSIS
@@ -617,7 +617,7 @@ Function SetProgramNetworkOptions {
 }
 
 
-Function SetProgramPackageMapping {
+Function Set-SWDProgramPackageMapping {
 
 <#
 .SYNOPSIS
@@ -675,7 +675,7 @@ Function SetProgramPackageMapping {
 }
 
 
-Function SetProgramRunOptions {
+Function Set-SWDProgramRunOptions {
 
 <#
 .SYNOPSIS

--- a/Functions/ScopingManagement.ps1
+++ b/Functions/ScopingManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AssignResourcesToOrganizationalGroup {
+Function Set-ResourcesToOrganizationalGroup {
 
 <#
 .SYNOPSIS
@@ -51,7 +51,7 @@ Function AssignResourcesToOrganizationalGroup {
 }
 
 
-Function AssignResourceTargetsToPolicy {
+Function Set-ResourceTargetsToPolicy {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function AssignResourceTargetsToPolicy {
 }
 
 
-Function AssignRoleToOrganizationalGroup {
+Function Set-RoleToOrganizationalGroup {
 
 <#
 .SYNOPSIS
@@ -155,7 +155,7 @@ Function AssignRoleToOrganizationalGroup {
 }
 
 
-Function CreateOrganizationalGroup {
+Function New-OrganizationalGroup {
 
 <#
 .SYNOPSIS
@@ -219,7 +219,7 @@ Function CreateOrganizationalGroup {
 }
 
 
-Function CreateOrganizationalView {
+Function New-OrganizationalView {
 
 <#
 .SYNOPSIS
@@ -271,7 +271,7 @@ Function CreateOrganizationalView {
 }
 
 
-Function CreateResourceTarget {
+Function New-ResourceTarget {
 
 <#
 .SYNOPSIS
@@ -317,7 +317,7 @@ Function CreateResourceTarget {
 }
 
 
-Function DeleteOrganizationalGroup {
+Function Remove-OrganizationalGroup {
 
 <#
 .SYNOPSIS
@@ -363,7 +363,7 @@ Function DeleteOrganizationalGroup {
 }
 
 
-Function DeleteOrganizationalView {
+Function Remove-OrganizationalView {
 
 <#
 .SYNOPSIS
@@ -409,7 +409,7 @@ Function DeleteOrganizationalView {
 }
 
 
-Function GetOrganizationalGroupDirectMembership {
+Function Get-OrganizationalGroupDirectMembership {
 
 <#
 .SYNOPSIS
@@ -455,7 +455,7 @@ Function GetOrganizationalGroupDirectMembership {
 }
 
 
-Function GetOrganizationalGroupMembership {
+Function Get-OrganizationalGroupMembership {
 
 <#
 .SYNOPSIS
@@ -501,7 +501,7 @@ Function GetOrganizationalGroupMembership {
 }
 
 
-Function GetOrganizationalGroupsFromOrganizationalView {
+Function Get-OrganizationalGroupsFromOrganizationalView {
 
 <#
 .SYNOPSIS
@@ -547,7 +547,7 @@ Function GetOrganizationalGroupsFromOrganizationalView {
 }
 
 
-Function GetOrganizationalViews {
+Function Get-OrganizationalViews {
 
 <#
 .SYNOPSIS
@@ -587,7 +587,7 @@ Function GetOrganizationalViews {
 }
 
 
-Function GetOrganizationalViewsFolderGuid {
+Function Get-OrganizationalViewsFolderGuid {
 
 <#
 .SYNOPSIS
@@ -627,7 +627,7 @@ Function GetOrganizationalViewsFolderGuid {
 }
 
 
-Function GetResourcesTargetedByPolicy {
+Function Get-ResourcesTargetedByPolicy {
 
 <#
 .SYNOPSIS
@@ -673,7 +673,7 @@ Function GetResourcesTargetedByPolicy {
 }
 
 
-Function GetResourceTargetMembership {
+Function Get-ResourceTargetMembership {
 
 <#
 .SYNOPSIS
@@ -719,7 +719,7 @@ Function GetResourceTargetMembership {
 }
 
 
-Function GetResourceTargets {
+Function Get-ResourceTargets {
 
 <#
 .SYNOPSIS
@@ -765,7 +765,7 @@ Function GetResourceTargets {
 }
 
 
-Function IsInOrganizationalGroup {
+Function Test-ItemIsInOrganizationalGroup {
 
 <#
 .SYNOPSIS
@@ -817,7 +817,7 @@ Function IsInOrganizationalGroup {
 }
 
 
-Function IsInOrganizationalGroupDirectMembership {
+Function Test-ItemIsInOrganizationalGroupDirectMembership {
 
 <#
 .SYNOPSIS
@@ -869,7 +869,7 @@ Function IsInOrganizationalGroupDirectMembership {
 }
 
 
-Function MoveOrganizationalGroupWithinOrganizationalView {
+Function Move-OrganizationalGroupWithinOrganizationalView {
 
 <#
 .SYNOPSIS
@@ -921,7 +921,7 @@ Function MoveOrganizationalGroupWithinOrganizationalView {
 }
 
 
-Function RemoveResourcesFromOrganizationalGroup {
+Function Remove-ResourcesFromOrganizationalGroup {
 
 <#
 .SYNOPSIS

--- a/Functions/SecurityManagement.ps1
+++ b/Functions/SecurityManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddRoleMembers {
+Function Add-RoleMembers {
 
 <#
 .SYNOPSIS
@@ -51,7 +51,7 @@ Function AddRoleMembers {
 }
 
 
-Function AddRolePrivileges {
+Function Add-RolePrivileges {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function AddRolePrivileges {
 }
 
 
-Function AssignItemOwnership {
+Function Set-ItemOwnership {
 
 <#
 .SYNOPSIS
@@ -155,7 +155,7 @@ Function AssignItemOwnership {
 }
 
 
-Function CreateNewRole {
+Function New-Role {
 
 <#
 .SYNOPSIS
@@ -207,7 +207,7 @@ Function CreateNewRole {
 }
 
 
-Function DeleteRole {
+Function Remove-Role {
 
 <#
 .SYNOPSIS
@@ -253,7 +253,7 @@ Function DeleteRole {
 }
 
 
-Function DisablePermissionInheritance {
+Function Disable-PermissionInheritance {
 
 <#
 .SYNOPSIS
@@ -305,7 +305,7 @@ Function DisablePermissionInheritance {
 }
 
 
-Function EnablePermissionInheritance {
+Function Enable-PermissionInheritance {
 
 <#
 .SYNOPSIS
@@ -351,7 +351,7 @@ Function EnablePermissionInheritance {
 }
 
 
-Function FindRoleByName {
+Function Find-RoleByName {
 
 <#
 .SYNOPSIS
@@ -397,7 +397,7 @@ Function FindRoleByName {
 }
 
 
-Function RemoveRoleMembers {
+Function Remove-RoleMembers {
 
 <#
 .SYNOPSIS
@@ -449,7 +449,7 @@ Function RemoveRoleMembers {
 }
 
 
-Function RemoveRolePrivileges {
+Function Remove-RolePrivileges {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwareCommandLineManagement.ps1
+++ b/Functions/SoftwareCommandLineManagement.ps1
@@ -1,5 +1,5 @@
 
-Function CreateCommandLine {
+Function New-CommandLine {
 
 <#
 .SYNOPSIS
@@ -99,7 +99,7 @@ Function CreateCommandLine {
 }
 
 
-Function DeleteCommandLine {
+Function Remove-CommandLine {
 
 <#
 .SYNOPSIS
@@ -145,7 +145,7 @@ Function DeleteCommandLine {
 }
 
 
-Function GetCommandLine {
+Function Get-CommandLine {
 
 <#
 .SYNOPSIS
@@ -191,7 +191,7 @@ Function GetCommandLine {
 }
 
 
-Function SetCommandLineProperty {
+Function Set-CommandLineProperty {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwareComponentManagement.ps1
+++ b/Functions/SoftwareComponentManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddAssociationToSoftwareComponent {
+Function Add-AssociationToSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function AddAssociationToSoftwareComponent {
 }
 
 
-Function AddCommandLineToSoftwareComponent {
+Function Add-CommandLineToSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -115,7 +115,7 @@ Function AddCommandLineToSoftwareComponent {
 }
 
 
-Function AddPackageToSoftwareComponent {
+Function Add-PackageToSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -167,7 +167,7 @@ Function AddPackageToSoftwareComponent {
 }
 
 
-Function AddRulesToSoftwareComponent {
+Function Add-RulesToSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -225,7 +225,7 @@ Function AddRulesToSoftwareComponent {
 }
 
 
-Function CreateServicePack {
+Function New-ServicePack {
 
 <#
 .SYNOPSIS
@@ -307,7 +307,7 @@ Function CreateServicePack {
 }
 
 
-Function CreateSoftwareRelease {
+Function New-SoftwareRelease {
 
 <#
 .SYNOPSIS
@@ -377,7 +377,7 @@ Function CreateSoftwareRelease {
 }
 
 
-Function CreateSoftwareUpdate {
+Function New-SoftwareUpdate {
 
 <#
 .SYNOPSIS
@@ -453,7 +453,7 @@ Function CreateSoftwareUpdate {
 }
 
 
-Function DetailedExport {
+Function Get-DetailedExport {
 
 <#
 .SYNOPSIS
@@ -511,7 +511,7 @@ Function DetailedExport {
 }
 
 
-Function DetailedImport {
+Function Get-DetailedImport {
 
 <#
 .SYNOPSIS
@@ -557,7 +557,7 @@ Function DetailedImport {
 }
 
 
-Function GetAssociatedResources {
+Function Get-AssociatedResources {
 
 <#
 .SYNOPSIS
@@ -603,7 +603,7 @@ Function GetAssociatedResources {
 }
 
 
-Function GetSoftwareComponent {
+Function Get-SoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -649,7 +649,7 @@ Function GetSoftwareComponent {
 }
 
 
-Function ImportSoftwareRelease {
+Function Import-SoftwareRelease {
 
 <#
 .SYNOPSIS
@@ -755,7 +755,7 @@ Function ImportSoftwareRelease {
 }
 
 
-Function RemoveAssociationFromSoftwareComponent {
+Function Remove-AssociationFromSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -807,7 +807,7 @@ Function RemoveAssociationFromSoftwareComponent {
 }
 
 
-Function RemoveCommandLineFromSoftwareComponent {
+Function Remove-CommandLineFromSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -859,7 +859,7 @@ Function RemoveCommandLineFromSoftwareComponent {
 }
 
 
-Function RemovePackageFromSoftwareComponent {
+Function Remove-PackageFromSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -911,7 +911,7 @@ Function RemovePackageFromSoftwareComponent {
 }
 
 
-Function RemoveRulesFromSoftwareComponent {
+Function Remove-RulesFromSoftwareComponent {
 
 <#
 .SYNOPSIS
@@ -963,7 +963,7 @@ Function RemoveRulesFromSoftwareComponent {
 }
 
 
-Function ResolveDuplicatedSoftware {
+Function Resolve-DuplicatedSoftware {
 
 <#
 .SYNOPSIS
@@ -1081,7 +1081,7 @@ Function ResolveDuplicatedSoftware {
 }
 
 
-Function SetSoftwareComponentProperty {
+Function Set-SoftwareComponentProperty {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwareDeliveryPolicyManagement.ps1
+++ b/Functions/SoftwareDeliveryPolicyManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddDeliveryItem {
+Function Add-SoftwareDeliveryItem {
 
 <#
 .SYNOPSIS
@@ -51,7 +51,7 @@ Function AddDeliveryItem {
 }
 
 
-Function CreatePolicy {
+Function New-SoftwareDeliveryPolicy {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function CreatePolicy {
 }
 
 
-Function GetDefaultPolicySetting {
+Function Get-SoftwareDeliveryDefaultPolicySetting {
 
 <#
 .SYNOPSIS
@@ -149,7 +149,7 @@ Function GetDefaultPolicySetting {
 }
 
 
-Function GetDeliveryItems {
+Function Get-SoftwareDeliveryItems {
 
 <#
 .SYNOPSIS
@@ -195,7 +195,7 @@ Function GetDeliveryItems {
 }
 
 
-Function GetDeliveryItemSetting {
+Function Get-SoftwareDeliveryItemSetting {
 
 <#
 .SYNOPSIS
@@ -253,7 +253,7 @@ Function GetDeliveryItemSetting {
 }
 
 
-Function GetPolicySetting {
+Function Get-SoftwareDeliveryPolicySetting {
 
 <#
 .SYNOPSIS
@@ -305,7 +305,7 @@ Function GetPolicySetting {
 }
 
 
-Function RemoveDeliveryItem {
+Function Remove-SoftwareDeliveryItem {
 
 <#
 .SYNOPSIS
@@ -357,7 +357,7 @@ Function RemoveDeliveryItem {
 }
 
 
-Function SetDefaultPolicySetting {
+Function Set-SoftwareDeliveryDefaultPolicySetting {
 
 <#
 .SYNOPSIS
@@ -409,7 +409,7 @@ Function SetDefaultPolicySetting {
 }
 
 
-Function SetDeliveryItemSetting {
+Function Set-SoftwareDeliveryItemSetting {
 
 <#
 .SYNOPSIS
@@ -473,7 +473,7 @@ Function SetDeliveryItemSetting {
 }
 
 
-Function SetPolicySetting {
+Function Set-SoftwareDeliveryPolicySetting {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwarePackageManagement.ps1
+++ b/Functions/SoftwarePackageManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddFile {
+Function Add-SWPackageFile {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function AddFile {
 }
 
 
-Function CreatePackage {
+Function New-SWPackage {
 
 <#
 .SYNOPSIS
@@ -145,7 +145,7 @@ Function CreatePackage {
 }
 
 
-Function DeletePackage {
+Function Remove-SWPackage {
 
 <#
 .SYNOPSIS
@@ -191,7 +191,7 @@ Function DeletePackage {
 }
 
 
-Function GetPackage {
+Function Get-SWPackage {
 
 <#
 .SYNOPSIS
@@ -237,7 +237,7 @@ Function GetPackage {
 }
 
 
-Function RemoveFile {
+Function Remove-SWFile {
 
 <#
 .SYNOPSIS
@@ -295,7 +295,7 @@ Function RemoveFile {
 }
 
 
-Function SetPackageProperty {
+Function Set-SWPackageProperty {
 
 <#
 .SYNOPSIS
@@ -359,7 +359,7 @@ Function SetPackageProperty {
 }
 
 
-Function SetPackageServerSettings {
+Function Set-SWPackageServerSettings {
 
 <#
 .SYNOPSIS
@@ -429,7 +429,7 @@ Function SetPackageServerSettings {
 }
 
 
-Function SetPackageSource {
+Function Set-SWPackageSource {
 
 <#
 .SYNOPSIS
@@ -499,7 +499,7 @@ Function SetPackageSource {
 }
 
 
-Function UpdateDistributionPoints {
+Function Update-SWDistributionPoints {
 
 <#
 .SYNOPSIS
@@ -545,7 +545,7 @@ Function UpdateDistributionPoints {
 }
 
 
-Function ValidateSoftwareLibrary {
+Function Confirm-SWSoftwareLibrary {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwarePortalManagement.ps1
+++ b/Functions/SoftwarePortalManagement.ps1
@@ -1,5 +1,5 @@
 
-Function AddUserOrGroupToPublishingItem {
+Function Add-SWPortalUserOrGroupToPublishingItem {
 
 <#
 .SYNOPSIS
@@ -63,7 +63,7 @@ Function AddUserOrGroupToPublishingItem {
 }
 
 
-Function GetSoftwarePortalSetting {
+Function Get-SWPortalSetting {
 
 <#
 .SYNOPSIS
@@ -109,7 +109,7 @@ Function GetSoftwarePortalSetting {
 }
 
 
-Function GetSoftwareRequestsForAdmin {
+Function Get-SWPortalRequestsForAdmin {
 
 <#
 .SYNOPSIS
@@ -149,7 +149,7 @@ Function GetSoftwareRequestsForAdmin {
 }
 
 
-Function GetSoftwareRequestsForManager {
+Function Get-SWPortalRequestsForManager {
 
 <#
 .SYNOPSIS
@@ -195,7 +195,7 @@ Function GetSoftwareRequestsForManager {
 }
 
 
-Function GetUsersForPublishingItem {
+Function Get-SWPortalUsersForPublishingItem {
 
 <#
 .SYNOPSIS
@@ -241,7 +241,7 @@ Function GetUsersForPublishingItem {
 }
 
 
-Function PublishPolicy {
+Function Publish-SWPortalPolicy {
 
 <#
 .SYNOPSIS
@@ -299,7 +299,7 @@ Function PublishPolicy {
 }
 
 
-Function PublishSoftwareResource {
+Function Publish-SWPortalResource {
 
 <#
 .SYNOPSIS
@@ -363,7 +363,7 @@ Function PublishSoftwareResource {
 }
 
 
-Function RemoveUserOrGroupFromPublishingItem {
+Function Remove-SWPortalUserOrGroupFromPublishingItem {
 
 <#
 .SYNOPSIS
@@ -415,7 +415,7 @@ Function RemoveUserOrGroupFromPublishingItem {
 }
 
 
-Function SetSoftwarePortalSetting {
+Function Set-SWPortalSetting {
 
 <#
 .SYNOPSIS
@@ -467,7 +467,7 @@ Function SetSoftwarePortalSetting {
 }
 
 
-Function SoftwareRequestAction {
+Function Set-SWPortalRequestAction {
 
 <#
 .SYNOPSIS
@@ -485,7 +485,7 @@ Function SoftwareRequestAction {
 .EXAMPLE 
      
 
-.NOTES
+.NOTES No idea what this does, Set- verb may not be proper for this function, I don't have SW Portal setup in my environment unable to test.
     
 #>
     

--- a/Functions/SoftwareProductManagement.ps1
+++ b/Functions/SoftwareProductManagement.ps1
@@ -1,5 +1,5 @@
 
-Function CreateSoftwareProduct {
+Function New-SWProduct {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function CreateSoftwareProduct {
 }
 
 
-Function GetSoftwareComponents {
+Function Get-SWProductComponents {
 
 <#
 .SYNOPSIS
@@ -109,7 +109,7 @@ Function GetSoftwareComponents {
 }
 
 
-Function GetSoftwareProduct {
+Function Get-SWProduct {
 
 <#
 .SYNOPSIS

--- a/Functions/SoftwareTasksManagement.ps1
+++ b/Functions/SoftwareTasksManagement.ps1
@@ -1,5 +1,5 @@
 
-Function CreateAssignPackagesToSoftwareResourceTask {
+Function New-SWTaskAssignPackagesToSoftwareResource {
 
 <#
 .SYNOPSIS
@@ -51,7 +51,7 @@ Function CreateAssignPackagesToSoftwareResourceTask {
 }
 
 
-Function CreatePackageDeliveryTask {
+Function New-SWTaskPackageDelivery {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function CreatePackageDeliveryTask {
 }
 
 
-Function CreateQuickDeliveryTask {
+Function New-SWTaskQuickDelivery {
 
 <#
 .SYNOPSIS
@@ -161,7 +161,7 @@ Function CreateQuickDeliveryTask {
 }
 
 
-Function CreateSourcePathUpdateTask {
+Function New-SWTaskSourcePathUpdate {
 
 <#
 .SYNOPSIS
@@ -225,7 +225,7 @@ Function CreateSourcePathUpdateTask {
 }
 
 
-Function CreateVirtualizationTask {
+Function New-SWTaskVirtualization {
 
 <#
 .SYNOPSIS
@@ -289,7 +289,7 @@ Function CreateVirtualizationTask {
 }
 
 
-Function CreateWindowsInstallerRepairTask {
+Function New-SWTaskWindowsInstallerRepair {
 
 <#
 .SYNOPSIS
@@ -335,7 +335,7 @@ Function CreateWindowsInstallerRepairTask {
 }
 
 
-Function RunAssignPackagesToSoftwareResourceTask {
+Function Invoke-SWTaskAssignPackagesToSoftwareResource {
 
 <#
 .SYNOPSIS

--- a/Functions/TaskManagement.ps1
+++ b/Functions/TaskManagement.ps1
@@ -1,5 +1,5 @@
 
-Function ExecuteTask {
+Function Invoke-Task {
 
 <#
 .SYNOPSIS
@@ -57,7 +57,7 @@ Function ExecuteTask {
 }
 
 
-Function GetExecutedTaskInstances {
+Function Get-TaskExecutedInstances {
 
 <#
 .SYNOPSIS
@@ -103,7 +103,7 @@ Function GetExecutedTaskInstances {
 }
 
 
-Function GetTask {
+Function Get-Task {
 
 <#
 .SYNOPSIS
@@ -149,7 +149,7 @@ Function GetTask {
 }
 
 
-Function GetTaskResourceStatus {
+Function Get-TaskResourceStatus {
 
 <#
 .SYNOPSIS
@@ -201,7 +201,7 @@ Function GetTaskResourceStatus {
 }
 
 
-Function GetTasks {
+Function Get-Tasks {
 
 <#
 .SYNOPSIS
@@ -247,7 +247,7 @@ Function GetTasks {
 }
 
 
-Function GetTasksByType {
+Function Get-TasksByType {
 
 <#
 .SYNOPSIS
@@ -299,7 +299,7 @@ Function GetTasksByType {
 }
 
 
-Function GetTaskStatus {
+Function Get-TaskStatus {
 
 <#
 .SYNOPSIS
@@ -345,7 +345,7 @@ Function GetTaskStatus {
 }
 
 
-Function ScheduleTaskCustom {
+Function Set-TaskScheduleCustom {
 
 <#
 .SYNOPSIS
@@ -415,7 +415,7 @@ Function ScheduleTaskCustom {
 }
 
 
-Function ScheduleTaskShared {
+Function Set-TaskScheduleShared {
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
All functions now have proper verb-noun names. As more people use the
module there may be some that need to be renamed to make more sense as I
was just going off the Symantec verbs.
